### PR TITLE
Move the call to requestTrackingAuthorization applicationDidBecomeActive Fixes AppsFlyerSDK/appsflyer-sdk-v6-sample-app#4

### DIFF
--- a/swift/sdk-v6-demo/sdk-v6-demo/AppDelegate.swift
+++ b/swift/sdk-v6-demo/sdk-v6-demo/AppDelegate.swift
@@ -33,21 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AppsFlyerLib.shared().delegate = self
         //  Set isDebug to true to see AppsFlyer debug logs
         AppsFlyerLib.shared().isDebug = true      
-        
-        // The following block is optional for applications wishing to give users the option to collect IDFA.
-        // for iOS 14 and above - The user may be prompted to collect IDFA.
-        //                        If user opts-in, the IDFA will be collected by the SDK.
-        // for iOS 13 and below - The IDFA will be collected by the SDK. The user will NOT be prompted to consent.
-        if #available(iOS 14, *) {
-            // Set a timeout for the SDK to wait for the IDFA collection before handling app launch
-            // If timeout expires before the user allows to collect IDFA , the IDFA will NOT be collected.
-            AppsFlyerLib.shared().waitForATTUserAuthorization(timeoutInterval: 60)
-            // Show the user the Apple IDFA consent dialog (AppTrackingTransparency)
-            // MUST be called here before start() in order to allow IDFA collection by the SDK
-            ATTrackingManager.requestTrackingAuthorization { (status) in
-            }
-        }
-        
+
         // iOS 10 or later
         if #available(iOS 10, *) {
             UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in }
@@ -63,6 +49,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func applicationDidBecomeActive(_ application: UIApplication) {
+        // The following block is optional for applications wishing to give users the option to collect IDFA.
+        // for iOS 14 and above - The user may be prompted to collect IDFA.
+        //                        If user opts-in, the IDFA will be collected by the SDK.
+        // for iOS 13 and below - The IDFA will be collected by the SDK. The user will NOT be prompted to consent.
+        if #available(iOS 14, *) {
+            // Set a timeout for the SDK to wait for the IDFA collection before handling app launch
+            // If timeout expires before the user allows to collect IDFA , the IDFA will NOT be collected.
+            AppsFlyerLib.shared().waitForATTUserAuthorization(timeoutInterval: 60)
+            // Show the user the Apple IDFA consent dialog (AppTrackingTransparency)
+            // MUST be called here before start() in order to allow IDFA collection by the SDK
+            ATTrackingManager.requestTrackingAuthorization { (status) in
+            }
+        }
+
         // Start the SDK (start the IDFA timeout set above, for iOS 14 or later)
         AppsFlyerLib.shared().start()
     }


### PR DESCRIPTION
As is stated in Apple documentation.

In iOS 14 applicationDidBecomeActive still worked when called form didFinishLaunchingWithOptions but not in iOS 15.